### PR TITLE
Binarized Neural Net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mlpcode.egg-info
 .dmypy.json
 models
 .idea
+nn.config.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mlpcode.egg-info
 *-ubyte
 *.lock
 *.npy
+.idea

--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -86,16 +86,22 @@ def leaky_relu_derivative(dA, z):
     return dZ
 
 
+def hard_sigmoid(x):
+    xp = cp.get_array_module(x)
+    return xp.clip((x + 1.0) / 2, 0.0, 1.0)
+
+
 def unitstep(x):
     "x should be of the shape (n_features, n_samples)"
-    x[x>=0] = 1;
-    x[x<0] = -1
+    x[x >= 0] = 1
+    x[x < 0] = -1
     return x
 
 
 def hard_tanh(dA, z):
     # equivalent to max(-1, min(z, 1))
-    return z.clip(-1, 1)
+    # return z.clip(-1, 1)
+    return 2 * hard_sigmoid(z) - 1
 
 
 class ActivationFuncs(Enum):

--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -88,8 +88,9 @@ def leaky_relu_derivative(dA, z):
 
 def unitstep(x):
     "x should be of the shape (n_features, n_samples)"
-    xp = cp.get_array_module(x)
-    return xp.sign(x)
+    x[x>=0] = 1;
+    x[x<0] = -1
+    return x
 
 
 def hard_tanh(dA, z):

--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -52,10 +52,8 @@ def softmax(x):
 
 
 def softmax_derivative(dA, z):
-    # a = softmax(z)
-    # return a * (1 - a)
-    # No need for it actually
-    return cp.get_array_module(z).ones_like(z)
+    a = softmax(z)
+    return a * (1 - a)
 
 
 def relu(x):
@@ -100,8 +98,8 @@ def unitstep(x):
 
 def hard_tanh(dA, z):
     # equivalent to max(-1, min(z, 1))
-    # return z.clip(-1, 1)
-    return 2 * hard_sigmoid(z) - 1
+    return z.clip(-1, 1)
+    # return 2 * hard_sigmoid(z) - 1
 
 
 class ActivationFuncs(Enum):

--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -93,6 +93,7 @@ def unitstep(x):
 
 
 def hard_tanh(dA, z):
+    # equivalent to max(-1, min(z, 1))
     return z.clip(-1, 1)
 
 

--- a/mlpcode/loss.py
+++ b/mlpcode/loss.py
@@ -6,7 +6,7 @@ from enum import Enum
 # Y_hat is model output, and Y is the real label/output
 # The expected dimensions are k * m, where k in no of neurons in the output, and m is the batchsize
 
-# TODO: Look at https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/metrics/_classification.py#L2176
+# https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/metrics/_classification.py#L2176
 def cross_entropy_loss(Y_hat, Y):
     m = Y_hat.shape[1]
     xp = cp.get_array_module(Y_hat)

--- a/mlpcode/loss.py
+++ b/mlpcode/loss.py
@@ -11,6 +11,8 @@ def cross_entropy_loss(Y_hat, Y):
     m = Y_hat.shape[1]
     xp = cp.get_array_module(Y_hat)
 
+    Y_hat[Y_hat <= 1e-7] += 2.2251e-308
+
     L_sum = xp.sum(xp.multiply(Y, xp.log(Y_hat)))
     L = -(1.0 / m) * L_sum
     return L

--- a/mlpcode/network.py
+++ b/mlpcode/network.py
@@ -2,9 +2,10 @@ import cupy as cp
 import numpy as np
 from pathlib import Path
 from datetime import datetime
+from typing import List
 
 from mlpcode.activation import ACTIVATION_DERIVATIVES, ACTIVATION_FUNCTIONS
-from mlpcode.activation import ActivationFuncs as af, hard_sigmoid
+from mlpcode.activation import ActivationFuncs as af, unitstep
 from mlpcode.loss import LOSS_DERIVATES, LOSS_FUNCS
 from mlpcode.loss import LossFuncs as lf
 from mlpcode.utils import MODELDIR, DATASETS
@@ -27,7 +28,9 @@ class Network(object):
         if lossF == lf.cross_entropy and outAf not in (af.sigmoid, af.softmax):
             # My implementation for normal derivative of cross entropy is not stable enough
             # Luckily, it comes down to (output - target) when used with sigmoid or softmax
-            raise ValueError("Gotta use sigmoid or softmax with cross entropy loss")
+            raise ValueError(
+                "Gotta use sigmoid or softmax with cross entropy loss"
+            )
 
         if useGpu:
             self.xp = cp
@@ -37,20 +40,24 @@ class Network(object):
         self.layers = layers
         self.isBinarized = binarized
         if self.isBinarized:
-            self.non_binarized_weights = None
-            self.non_binarized_biases = None
+            self.non_binarized_weights: List[np.ndarray] = []
+            self.non_binarized_biases: List[np.ndarray] = []
 
         if fineTuning:
-            self.weights, self.biases = None, None
+            self.weights, self.biases = [], []
         else:
             # Xavier init
             self.biases = [self.xp.random.randn(y, 1) for y in layers[1:]]
             self.weights = [
-                (self.xp.random.randn(l, l_minus_1) * self.xp.sqrt(1 / l_minus_1))
+                (
+                    self.xp.random.randn(l, l_minus_1)
+                    * self.xp.sqrt(1 / l_minus_1)
+                )
                 for l_minus_1, l in zip(layers[:-1], layers[1:])
             ]
 
         cp.cuda.Stream.null.synchronize()
+        self.lossF = lossF
         self.loss = LOSS_FUNCS[lossF]
         self.loss_derivative = LOSS_DERIVATES[lossF]
         self.hiddenDerivative = ACTIVATION_DERIVATIVES[hiddenAf]
@@ -98,22 +105,26 @@ class Network(object):
             keyArr = npzfile.files
             assert len(keyArr) == 3
             # Conversion done for the same reason allow_pickle is used above
-            nn.weights = [nn.xp.array(x, dtype=nn.xp.float) for x in npzfile[keyArr[0]]]
-            nn.biases = [nn.xp.array(x, dtype=nn.xp.float) for x in npzfile[keyArr[1]]]
+            nn.weights = [
+                nn.xp.array(x, dtype=nn.xp.float) for x in npzfile[keyArr[0]]
+            ]
+            nn.biases = [
+                nn.xp.array(x, dtype=nn.xp.float) for x in npzfile[keyArr[1]]
+            ]
             # Just to ensure consistency
             nn.layers = list(map(int, fp[keyArr[2]]))
             nn.num_layers = len(nn.layers) - 1
             hiddenActivationFunc = ACTIVATION_FUNCTIONS[hiddenAf]
             outputActivationFunc = ACTIVATION_FUNCTIONS[outAf]
-            nn.activations = [hiddenActivationFunc for _ in range(nn.num_layers - 1)]
+            nn.activations = [
+                hiddenActivationFunc for _ in range(nn.num_layers - 1)
+            ]
             nn.activations.append(outputActivationFunc)
         return nn
 
     @staticmethod
     def binarize(x):
-        newX = x.copy()
-        newX[x >= 0] = 1
-        newX[x < 0] = -1
+        newX = unitstep(x.copy())
         cp.cuda.Stream.null.synchronize()
         return newX
 
@@ -190,7 +201,13 @@ class Network(object):
             costList.append(cost)
             print(
                 "Epoch {0}:\t{1} Acc: {2} / {3} ({4:.05f}%)\t{5} Loss: {6:.02f}".format(
-                    j + 1, accType, correct, n_test, float(acc), accType, float(cost)
+                    j + 1,
+                    accType,
+                    correct,
+                    n_test,
+                    float(acc),
+                    accType,
+                    float(cost),
                 )
             )
 
@@ -212,7 +229,9 @@ class Network(object):
         x, y = batch
         m = x.shape[0] * 1.0
         if self.isBinarized:
-            self.weights = [self.binarize(w) for w in self.non_binarized_weights]
+            self.weights = [
+                self.binarize(w) for w in self.non_binarized_weights
+            ]
             self.biases = [self.binarize(b) for b in self.non_binarized_biases]
         delta_nabla_b, delta_nabla_w, cost = self.backprop(x.T, y.T)
         cp.cuda.Stream.null.synchronize()
@@ -233,14 +252,20 @@ class Network(object):
         cp.cuda.Stream.null.synchronize()
         if self.isBinarized:
             self.non_binarized_weights = [
-                w - (eta * nw) for w, nw in zip(self.non_binarized_weights, nabla_w)
+                w - (eta * nw)
+                for w, nw in zip(self.non_binarized_weights, nabla_w)
             ]
             self.non_binarized_biases = [
-                b - (eta * nb) for b, nb in zip(self.non_binarized_biases, nabla_b)
+                b - (eta * nb)
+                for b, nb in zip(self.non_binarized_biases, nabla_b)
             ]
         else:
-            self.weights = [w - (eta * nw) for w, nw in zip(self.weights, nabla_w)]
-            self.biases = [b - (eta * nb) for b, nb in zip(self.biases, nabla_b)]
+            self.weights = [
+                w - (eta * nw) for w, nw in zip(self.weights, nabla_w)
+            ]
+            self.biases = [
+                b - (eta * nb) for b, nb in zip(self.biases, nabla_b)
+            ]
         cp.cuda.Stream.null.synchronize()
         return cost
 
@@ -256,7 +281,9 @@ class Network(object):
         # backward pass
         dLdA = self.loss_derivative(activation, y)  # expected shape: k * n
         cp.cuda.Stream.null.synchronize()
-        if self.outAF in (af.softmax, af.identity):
+        if (self.outAF == af.identity) or (
+            self.outAF == af.softmax and self.lossF == lf.cross_entropy
+        ):
             delta = dLdA
         else:
             dAdZ = self.outputDerivative(dLdA, zs[-1])

--- a/mlpcode/network.py
+++ b/mlpcode/network.py
@@ -192,10 +192,12 @@ class Network(object):
         x, y = batch
 
         m = x.shape[0] * 1.0
-        if self.isBinarized:
-            self.weights = [self.binarize(w) for w in self.weights]
-            self.biases = [self.binarize(b) for b in self.biases]
-            cp.cuda.Stream.null.synchronize()
+
+        # if self.isBinarized:
+        #     self.weights = [self.binarize(w) for w in self.weights]
+        #     self.biases = [self.binarize(b) for b in self.biases]
+        #     cp.cuda.Stream.null.synchronize()
+
         delta_nabla_b, delta_nabla_w, cost = self.backprop(x.T, y.T)
         cp.cuda.Stream.null.synchronize()
         # matrix.sum(axis=0) => 3
@@ -219,10 +221,10 @@ class Network(object):
         self.biases = [b - (eta * nb) for b, nb in zip(self.biases, nabla_b)]
 
         cp.cuda.Stream.null.synchronize()
-        if self.isBinarized:
-            self.weights = [self.xp.clip(w, -1.0, 1.0) for w in self.weights]
-            self.biases = [self.xp.clip(b, -1.0, 1.0) for b in self.biases]
-            cp.cuda.Stream.null.synchronize()
+        # if self.isBinarized:
+        #     self.weights = [self.xp.clip(w, -1.0, 1.0) for w in self.weights]
+        #     self.biases = [self.xp.clip(b, -1.0, 1.0) for b in self.biases]
+        #     cp.cuda.Stream.null.synchronize()
 
         return cost
 

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -19,7 +19,7 @@ nn = Network(
     hiddenAf=af.sign,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
-    binarized=True,
+    binarized=False,
 )
 
 # Creating from a pretrained model

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -8,18 +8,18 @@ dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset)
 print("Finished loading {} data".format(dataset))
-layers = [784, 64, 10]
-epochs = 500
+layers = [784, 500, 1000, 10]
+epochs = 100
 print("Creating neural net")
 
 # Creating from scratch
 nn = Network(
     layers,
     useGpu=useGpu,
-    hiddenAf=af.sign,
+    hiddenAf=af.leaky_relu,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
-    binarized=True,
+    binarized=False,
 )
 
 # Creating from a pretrained model
@@ -34,4 +34,4 @@ nn = Network(
 # )
 
 # Save must be the name of the dataset, if we want to save the model
-nn.train(trainX, trainY, epochs, batch_size=600, lr=1e-3, save=dataset)
+nn.train(trainX, trainY, epochs, batch_size=100, lr=0.07)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -4,20 +4,20 @@ from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset
 
 useGpu = True
-dataset = DATASETS.mnistc_rotate
+dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
-trainX, trainY, testX, testY = loadDataset(DATASETS.fashion)
+trainX, trainY, testX, testY = loadDataset(dataset)
 print("Finished loading {} data".format(dataset))
-layers = [784, 64, 10]
+layers = [784, 500, 1000, 10]
 epochs = 500
 print("Creating neural net")
-# Don't use cross entropy until I include a method to turn Y labels to one-hot-encoded vectors
 nn = Network(
     layers,
     useGpu=useGpu,
-    hiddenAf=af.leaky_relu,
+    hiddenAf=af.sign,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
+    binarized=True
 )
 
-nn.train(trainX, trainY, epochs, 600, 1e-3, testX, testY)
+nn.train(trainX, trainY, epochs, 100, 0.007, testX, testY)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -8,7 +8,7 @@ dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset)
 print("Finished loading {} data".format(dataset))
-layers = [784, 500, 1000, 10]
+layers = [784, 500, 10]
 epochs = 100
 print("Creating neural net")
 
@@ -19,7 +19,7 @@ nn = Network(
     hiddenAf=af.leaky_relu,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
-    binarized=False,
+    binarized=True,
 )
 
 # Creating from a pretrained model

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -17,7 +17,7 @@ nn = Network(
     hiddenAf=af.sign,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
-    binarized=True
+    binarized=True,
 )
 
-nn.train(trainX, trainY, epochs, 100, 0.007, testX, testY)
+nn.train(trainX, trainY, epochs, 100, 0.003, testX, testY)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -9,7 +9,7 @@ print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset)
 print("Finished loading {} data".format(dataset))
 layers = [784, 64, 10]
-epochs = 10
+epochs = 500
 print("Creating neural net")
 
 # Creating from scratch
@@ -19,7 +19,7 @@ nn = Network(
     hiddenAf=af.sign,
     outAf=af.softmax,
     lossF=lf.cross_entropy,
-    binarized=False,
+    binarized=True,
 )
 
 # Creating from a pretrained model

--- a/mlpcode/utils.py
+++ b/mlpcode/utils.py
@@ -7,16 +7,24 @@ import struct
 import json
 from enum import Enum
 
+# TODO: Save the config
+prnt = Path(__file__).parent
+
 # CONFIGURATION
-CONFIG_FILE = Path("./nn.config.json")
+CONFIG_FILE = prnt / "nn.config.json"
 if CONFIG_FILE.exists():
+    print(f"Reading config from {CONFIG_FILE}")
     with CONFIG_FILE.open("r") as f:
-        config = json.load()
+        tmp = json.load(f)
+        config = {k: Path(tmp[k]) for k in tmp.keys()}
 else:
-    prnt = Path(__file__).parent
     config = {"DATADIR": prnt / "data", "MODELDIR": prnt / "models"}
     if not config["MODELDIR"].exists():
         config["MODELDIR"].mkdir()
+    with CONFIG_FILE.open("w") as f:
+        json.dump({k: str(config[k]) for k in config.keys()}, f)
+    print(f"Wrote config to {CONFIG_FILE}")
+
 
 # Data dir is just a folder named 'data' in the same directory where this file exists.
 # It should contain the required datasets on which the models are to be trained/tested

--- a/mlpcode/utils.py
+++ b/mlpcode/utils.py
@@ -7,7 +7,6 @@ import struct
 import json
 from enum import Enum
 
-# TODO: Save the config
 prnt = Path(__file__).parent
 
 # CONFIGURATION


### PR DESCRIPTION
- Weights (and biases) are initialized as {-1, 1}.
- After each backwards pass, the weights and biases are binarized (to ensure they are binary in the next run, and also when we save them).

- Results for [784, 64, 10] with batchsize 100 and learning rate 0.007: 
Epoch 246: 1094 / 10000 (10.94000%)	Test Loss: 12.51 (same as start)

- Results for [784, 500, 1000, 10] with batchsize 100 and learning rate 0.007: 
Epoch 31: 982 / 10000 (9.82000%)	Test Loss: 45.65 (same as start)
