### PR TITLE
Fixed CIFAR-10

### DIFF
--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -4,11 +4,11 @@ from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset, MODELDIR
 
 useGpu = True
-dataset = DATASETS.mnistc_dotted_line
+dataset = DATASETS.cifar10
 print("Loading {}".format(dataset))
-trainX, trainY, testX, testY = loadDataset(dataset)
+trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 print("Finished loading {} data".format(dataset))
-layers = [trainX.shape[1], 500, 10]
+layers = [trainX.shape[1], 512, 10]
 epochs = 100
 batchSize = 600
 lr = 0.01


### PR DESCRIPTION
There were two things causing the problem.

- Improper casting of the dataset (it was being cast to uint8 from float32 at one point, which caused it to lose all information)

- Double normalization (the dataset was saved in normalized form, and was normalized again, which would have lead to problems even if point 1 was resolved).

Both these have been resolved. CIFAR-10 is showing performance similar to a keras network with the same architecture (tested). 