### PR TITLE
Fix loading cp weights using np

### DIFF
--- a/mlpcode/loss.py
+++ b/mlpcode/loss.py
@@ -8,6 +8,7 @@ from enum import Enum
 
 # https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/metrics/_classification.py#L2176
 def cross_entropy_loss(Y_hat, Y):
+    # TODO: Implement fix for Y_hat == 0 when using binarized network
     m = Y_hat.shape[1]
     xp = cp.get_array_module(Y_hat)
 

--- a/mlpcode/network.py
+++ b/mlpcode/network.py
@@ -202,8 +202,11 @@ class Network(object):
 
             if save is not None and acc > best_accuracy:
                 best_accuracy = acc
-                best_weights = [w.copy() for w in self.weights]
-                best_biases = [b.copy() for b in self.biases]
+                # makes no sense to save the binarized weights if we need the non_binarized for finetuning
+                ws = self.non_binarized_weights if self.isBinarized else self.weights
+                bs = self.non_binarized_biases if self.isBinarized else self.biases
+                best_weights = [w.copy() for w in ws]
+                best_biases = [b.copy() for b in bs]
 
         if save is not None:
             print("\nBest Accuracy:\t{0:.03f}%".format(float(best_accuracy)))
@@ -252,8 +255,8 @@ class Network(object):
         return cost
 
     def backprop(self, x, y):
-        nabla_b = [None for b in self.biases]
-        nabla_w = [None for w in self.weights]
+        nabla_b = [None for _ in self.biases]
+        nabla_w = [None for _ in self.weights]
 
         # forward pass
         zs, activations, activation = self.feedforward(x)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -9,9 +9,9 @@ print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 print("Finished loading {} data".format(dataset))
 layers = [trainX.shape[1], 512, 10]
-epochs = 100
+epochs = 10
 batchSize = 600
-lr = 0.01
+lr = 1e-3
 print("Creating neural net")
 
 # Creating from scratch
@@ -36,4 +36,4 @@ nn = Network(
 # )
 
 # Save must be the name of the dataset, if we want to save the model
-nn.train(trainX, trainY, epochs, batch_size=batchSize, lr=lr)
+nn.train(trainX, trainY, epochs, batch_size=batchSize, lr=lr, save=dataset)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -3,15 +3,15 @@ from mlpcode.loss import LossFuncs as lf
 from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset, MODELDIR
 
-useGpu = True
-dataset = DATASETS.cifar10
+useGpu = False
+dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 print("Finished loading {} data".format(dataset))
 layers = [trainX.shape[1], 512, 10]
 epochs = 10
 batchSize = 600
-lr = 1e-3
+lr = 0.07
 print("Creating neural net")
 
 # Creating from scratch
@@ -25,14 +25,15 @@ nn = Network(
 )
 
 # Creating from a pretrained model
-# modelPath = MODELDIR / "mnist_c-rotate_1588597666.073832.npz"
+# modelPath = MODELDIR / "mnist_1589459230.202179.npz"
 # assert modelPath.exists()
 # nn = Network.fromModel(
 #     modelPath,
-#     useGpu=True,
+#     useGpu=useGpu,
 #     hiddenAf=af.leaky_relu,
 #     outAf=af.softmax,
 #     lossF=lf.cross_entropy,
+#     binarized=True,
 # )
 
 # Save must be the name of the dataset, if we want to save the model


### PR DESCRIPTION
Weights saved by cupy were causing problem when being loaded by numpy (cause of the absence of __array__ method in cp arrays. The same thing occurs if cp.copy is used)

- Some more changes are being made to reduce the memory footprint of the parameters and data whole training