### PR TITLE
Add feature - Decaying learning rate

### DIFF
--- a/mlpcode/optim.py
+++ b/mlpcode/optim.py
@@ -1,0 +1,69 @@
+from enum import Enum
+
+
+class LRSchedulerStrat(Enum):
+    na = "No Decay"
+    time = "time-based"
+    exp = "exponential"
+    drop = "drop-based"
+
+
+class LRScheduler:
+    def __init__(
+        self,
+        alpha=0.1,
+        decay_rate=None,
+        strategy: LRSchedulerStrat = LRSchedulerStrat.na,
+        drop_every_n=10,
+    ):
+        if decay_rate is None:
+            self.decayRate = self.get_default_decay_rate(strategy)
+        else:
+            if strategy == LRSchedulerStrat.exp and decay_rate > 1.0:
+                raise ValueError(
+                    "The decay rate must be less than one for exponential decay"
+                )
+            if strategy == LRSchedulerStrat.drop and decay_rate < 1:
+                raise ValueError(
+                    "The decay rate must be above 1 for drop based decay (otherwise LR will increase)"
+                )
+            self.decayRate = decay_rate
+
+        assert decay_rate >= 0.0
+        self._alpha0 = alpha
+        self.strategy = strategy
+        self.stepCount = 0
+        self._alpha = alpha
+        self.dropEveryN = drop_every_n
+        self.step()
+
+    @property
+    def value(self):
+        return self._alpha
+
+    @staticmethod
+    def get_default_decay_rate(strategy: LRSchedulerStrat):
+        if strategy == LRSchedulerStrat.na:
+            return 0.0
+        elif strategy == LRSchedulerStrat.time:
+            return 0.0
+        elif strategy == LRSchedulerStrat.exp:
+            return 1.0
+        elif strategy == LRSchedulerStrat.drop:
+            return 1.0
+        else:
+            raise ValueError("Invalid value for LR Decay Strategy")
+
+    def step(self):
+        if self.strategy == LRSchedulerStrat.na:
+            self._alpha = self._alpha0
+        elif self.strategy == LRSchedulerStrat.time:
+            self._alpha = 1.0 / (1 + self.decayRate * self.stepCount) * self._alpha0
+        elif self.strategy == LRSchedulerStrat.exp:
+            self._alpha = self._alpha0 * (self.decayRate ** self.stepCount)
+        elif self.strategy == LRSchedulerStrat.drop:
+            if (self.stepCount + 1) % self.dropEveryN == 0:
+                self._alpha = self._alpha0 / self.decayRate
+        else:
+            raise ValueError()
+        self.stepCount += 1

--- a/mlpcode/optim.py
+++ b/mlpcode/optim.py
@@ -30,16 +30,16 @@ class LRScheduler:
             self.decayRate = decay_rate
 
         assert decay_rate >= 0.0
-        self._alpha0 = alpha
+        self.__alpha0 = alpha
         self.strategy = strategy
-        self.stepCount = 0
-        self._alpha = alpha
-        self.dropEveryN = drop_every_n
+        self.__stepCount = 0
+        self.__alpha = alpha
+        self.__dropEveryN = drop_every_n
         self.step()
 
     @property
     def value(self):
-        return self._alpha
+        return self.__alpha
 
     @staticmethod
     def get_default_decay_rate(strategy: LRSchedulerStrat):
@@ -56,14 +56,14 @@ class LRScheduler:
 
     def step(self):
         if self.strategy == LRSchedulerStrat.na:
-            self._alpha = self._alpha0
+            self.__alpha = self.__alpha0
         elif self.strategy == LRSchedulerStrat.time:
-            self._alpha = 1.0 / (1 + self.decayRate * self.stepCount) * self._alpha0
+            self.__alpha = 1.0 / (1 + self.decayRate * self.__stepCount) * self.__alpha0
         elif self.strategy == LRSchedulerStrat.exp:
-            self._alpha = self._alpha0 * (self.decayRate ** self.stepCount)
+            self.__alpha = self.__alpha0 * (self.decayRate ** self.__stepCount)
         elif self.strategy == LRSchedulerStrat.drop:
-            if (self.stepCount + 1) % self.dropEveryN == 0:
-                self._alpha = self._alpha0 / self.decayRate
+            if (self.__stepCount + 1) % self.__dropEveryN == 0:
+                self.__alpha = self.__alpha0 / self.decayRate
         else:
             raise ValueError()
-        self.stepCount += 1
+        self.__stepCount += 1

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -2,8 +2,10 @@ from mlpcode.activation import ActivationFuncs as af
 from mlpcode.loss import LossFuncs as lf
 from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset, MODELDIR
+from mlpcode.optim import LRScheduler, LRSchedulerStrat as LRS
 
 useGpu = False
+binarized = False
 dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
@@ -11,30 +13,20 @@ print("Finished loading {} data".format(dataset))
 layers = [trainX.shape[1], 512, 10]
 epochs = 10
 batchSize = 600
-lr = 0.07
+# lr = 0.07
+lr = LRScheduler(alpha=0.07, decay_rate=2, strategy=LRS.drop)
 print("Creating neural net")
 
 # Creating from scratch
-nn = Network(
-    layers,
-    useGpu=useGpu,
-    hiddenAf=af.leaky_relu,
-    outAf=af.softmax,
-    lossF=lf.cross_entropy,
-    binarized=False,
-)
+nn = Network(layers, useGpu=useGpu, binarized=binarized,)
 
 # Creating from a pretrained model
-# modelPath = MODELDIR / "mnist_1589459230.202179.npz"
-# assert modelPath.exists()
-# nn = Network.fromModel(
-#     modelPath,
-#     useGpu=useGpu,
-#     hiddenAf=af.leaky_relu,
-#     outAf=af.softmax,
-#     lossF=lf.cross_entropy,
-#     binarized=True,
-# )
+modelPath = MODELDIR / "mnist_1589459230.202179.npz"
+assert modelPath.exists()
+# nn = Network.fromModel(modelPath, useGpu=useGpu, binarized=binarized,)
+
+# Must compile the model before trying to train it
+nn.compile(lr=lr, hiddenAf=af.leaky_relu, outAf=af.softmax, lossF=lf.cross_entropy)
 
 # Save must be the name of the dataset, if we want to save the model
-nn.train(trainX, trainY, epochs, batch_size=batchSize, lr=lr, save=dataset)
+nn.train(trainX, trainY, epochs, batch_size=batchSize, save=dataset)

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -14,7 +14,7 @@ layers = [trainX.shape[1], 512, 10]
 epochs = 10
 batchSize = 600
 # lr = 0.07
-lr = LRScheduler(alpha=0.07, decay_rate=2, strategy=LRS.drop)
+lr = LRScheduler(alpha=0.07, decay_rate=0.8, strategy=LRS.time)
 print("Creating neural net")
 
 # Creating from scratch


### PR DESCRIPTION
- Some of the initialization function arguments have been moved to `compile` function (like in Keras).
 It's done only to prevent cluttering the constructor and train function. Some other parts of the code have been refactored to separate functions as well to make the code look cleaner.

- There is an option to use batches while getting the accuracy on the test/validation set (`evaluate` function).

- A separate module named `optim` is available. For now, it contains LRScheduler (for decaying learning rate). I will add any training optimizations there (starting with momentum based gradient descent).

- LRScheduler class has four basic 'strategies' for decaying the learning rate.

- na (not any). Not use any decay

- time (time based. Most common one I've seen). The learning rate decreases by a fraction each time step. The decrease in the size of learning rate is like the decrease in gradient size (large at start, smaller with epochs).

- exp (exponential decay) The learning rate decays exponentially. Therefore, the decay rate must be less than 1. Otherwise the learning  rate will increase with time.

- drop (drop based): The learning rate is divided by the decay rate every n epochs. Here, the decay rate must be positive, otherwise the learning rate will increase. 

The defaults for each of these strategies simulate the na strategy for now. I'll change the defaults after testing some stuff and consulting the literature.

You can see a noticeable difference in the model performance by using any of these strategies. 

May add one more strategy in the future.

TESTED: GPU and CPU, Binarized and Conventional

@serco425 
@indexxy 