### PR TITLE
Add support for testing and saving binary versions of the model

### DIFF
--- a/mlpcode/optim.py
+++ b/mlpcode/optim.py
@@ -17,7 +17,7 @@ class LRScheduler:
         drop_every_n=10,
     ):
         if decay_rate is None:
-            self.decayRate = self.get_default_decay_rate(strategy)
+            self.__decayRate = self.get_default_decay_rate(strategy)
         else:
             if strategy == LRSchedulerStrat.exp and decay_rate > 1.0:
                 raise ValueError(
@@ -27,9 +27,9 @@ class LRScheduler:
                 raise ValueError(
                     "The decay rate must be above 1 for drop based decay (otherwise LR will increase)"
                 )
-            self.decayRate = decay_rate
+            self.__decayRate = decay_rate
 
-        assert decay_rate >= 0.0
+        assert self.__decayRate >= 0.0
         self.__alpha0 = alpha
         self.strategy = strategy
         self.__stepCount = 0
@@ -58,12 +58,14 @@ class LRScheduler:
         if self.strategy == LRSchedulerStrat.na:
             self.__alpha = self.__alpha0
         elif self.strategy == LRSchedulerStrat.time:
-            self.__alpha = 1.0 / (1 + self.decayRate * self.__stepCount) * self.__alpha0
+            self.__alpha = (
+                1.0 / (1 + self.__decayRate * self.__stepCount) * self.__alpha0
+            )
         elif self.strategy == LRSchedulerStrat.exp:
-            self.__alpha = self.__alpha0 * (self.decayRate ** self.__stepCount)
+            self.__alpha = self.__alpha0 * (self.__decayRate ** self.__stepCount)
         elif self.strategy == LRSchedulerStrat.drop:
             if (self.__stepCount + 1) % self.__dropEveryN == 0:
-                self.__alpha = self.__alpha0 / self.decayRate
+                self.__alpha = self.__alpha0 / self.__decayRate
         else:
             raise ValueError()
         self.__stepCount += 1

--- a/mlpcode/test.py
+++ b/mlpcode/test.py
@@ -4,8 +4,8 @@ from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset, MODELDIR
 from mlpcode.optim import LRScheduler, LRSchedulerStrat as LRS
 
-useGpu = False
-binarized = False
+useGpu = True
+binarized = True
 dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
@@ -13,20 +13,36 @@ print("Finished loading {} data".format(dataset))
 layers = [trainX.shape[1], 512, 10]
 epochs = 10
 batchSize = 600
-# lr = 0.07
-lr = LRScheduler(alpha=0.07, decay_rate=0.8, strategy=LRS.time)
-print("Creating neural net")
+lr = 0.07
+# lr = LRScheduler(alpha=0.07, decay_rate=0.8, strategy=LRS.time)
+print("\nCreating neural net")
 
 # Creating from scratch
-nn = Network(layers, useGpu=useGpu, binarized=binarized,)
+nn = Network(layers, useGpu=useGpu, binarized=binarized)
 
 # Creating from a pretrained model
-modelPath = MODELDIR / "mnist_1589459230.202179.npz"
-assert modelPath.exists()
-# nn = Network.fromModel(modelPath, useGpu=useGpu, binarized=binarized,)
+# modelPath = MODELDIR / "mnist_1589624361.944349.npz"
+# assert modelPath.exists()
+# nn = Network.fromModel(modelPath, useGpu=useGpu, binarized=binarized)
 
 # Must compile the model before trying to train it
 nn.compile(lr=lr, hiddenAf=af.leaky_relu, outAf=af.softmax, lossF=lf.cross_entropy)
 
-# Save must be the name of the dataset, if we want to save the model
-nn.train(trainX, trainY, epochs, batch_size=batchSize, save=dataset)
+# Save best will switch the model weights and biases to the ones with best accuracy at the end of the training loop
+nn.train(trainX, trainY, epochs, batch_size=batchSize, save_best_params=True)
+
+# Save will be called separately if we want to save the model
+# Set binarized to true if you want to save the binary version of the weights
+nn.save_weights(modelName=str(dataset), binarized=False)
+
+# Change binarized to true to get the accuracy using binarized weights
+testingType = "binarized"
+correct = nn.evaluate(
+    testX, testY, batch_size=batchSize, binarized=testingType == "binarized"
+)
+acc = correct / testX.shape[0] * 100.0
+print(
+    "Accuracy on test set with {3} testing:\t{0} / {1} : {2:.03f}%".format(
+        correct, testX.shape[0], acc, testingType
+    )
+)

--- a/mlpcode/utils.py
+++ b/mlpcode/utils.py
@@ -156,14 +156,14 @@ def loadY(file_pth: Path, loadFunc, useGpu=True, encoded=True):
     return y
 
 
-def loadTesting(dataDir: Path, useGpu=True, encoded=True):
+def loadTesting(dataDir: Path, useGpu=True):
     xPth: Path = dataDir / "t10k-images-idx3-ubyte"
     yPth: Path = dataDir / "t10k-labels-idx1-ubyte"
     assert xPth.exists()
     assert yPth.exists()
     instances = 10000
-    X = loadX(xPth, loadIdxFile, instances, 784, useGpu)
-    y = loadY(yPth, loadIdxFile, useGpu, encoded)
+    X = loadX(xPth, loadIdxFile, instances, 784, useGpu=useGpu)
+    y = loadY(yPth, loadIdxFile, useGpu=useGpu, encoded=False)
     return X, y
 
 
@@ -173,20 +173,18 @@ def loadTraining(dataDir: Path, useGpu=True, encoded=True):
     assert xPth.exists()
     assert yPth.exists()
     instances = 60000
-    X = loadX(xPth, loadIdxFile, instances, 784, useGpu)
-    y = loadY(yPth, loadIdxFile, useGpu, encoded)
+    X = loadX(xPth, loadIdxFile, instances, 784, useGpu=useGpu)
+    y = loadY(yPth, loadIdxFile, useGpu=useGpu, encoded=encoded)
     return X, y
 
 
-def loadNpyTesting(
-    dataDir: Path, instances: int, inputNeurons: int, useGpu=True, encoded=True
-):
+def loadNpyTesting(dataDir: Path, instances: int, inputNeurons: int, useGpu=True):
     xPth = dataDir / "test_images.npy"
     yPth = dataDir / "test_labels.npy"
     assert xPth.exists()
     assert yPth.exists()
-    X = loadX(xPth, loadNpyFile, instances, inputNeurons, useGpu)
-    y = loadY(yPth, loadNpyFile, useGpu, encoded)
+    X = loadX(xPth, loadNpyFile, instances, inputNeurons, useGpu=useGpu)
+    y = loadY(yPth, loadNpyFile, useGpu=useGpu, encoded=False)
     return X, y
 
 
@@ -197,8 +195,8 @@ def loadNpyTraining(
     yPth = dataDir / "train_labels.npy"
     assert xPth.exists()
     assert yPth.exists()
-    X = loadX(xPth, loadNpyFile, instances, inputNeurons, useGpu)
-    y = loadY(yPth, loadNpyFile, useGpu, encoded)
+    X = loadX(xPth, loadNpyFile, instances, inputNeurons, useGpu=useGpu)
+    y = loadY(yPth, loadNpyFile, useGpu=useGpu, encoded=encoded)
     return X, y
 
 
@@ -218,21 +216,19 @@ def loadMnistC(category: DATASETS, useGpu=True, encoded=True):
     trainX, trainY = loadNpyTraining(
         dirPth, trainInstances, inputNeurons, useGpu=useGpu, encoded=encoded
     )
-    testX, testY = loadNpyTesting(
-        dirPth, testInstances, inputNeurons, useGpu=useGpu, encoded=encoded
-    )
+    testX, testY = loadNpyTesting(dirPth, testInstances, inputNeurons, useGpu=useGpu)
     return trainX, trainY, testX, testY
 
 
 def loadMnist(useGpu=True, encoded=True):
-    trainX, trainY = loadTraining(MNISTDIR, useGpu, encoded)
-    testX, testY = loadTesting(MNISTDIR, useGpu, encoded)
+    trainX, trainY = loadTraining(MNISTDIR, useGpu=useGpu, encoded=encoded)
+    testX, testY = loadTesting(MNISTDIR, useGpu=useGpu)
     return trainX, trainY, testX, testY
 
 
 def loadFashionMnist(useGpu=True, encoded=True):
-    trainX, trainY = loadTraining(FASHIONMNISTDIR, useGpu, encoded)
-    testX, testY = loadTesting(FASHIONMNISTDIR, useGpu, encoded)
+    trainX, trainY = loadTraining(FASHIONMNISTDIR, useGpu=useGpu, encoded=encoded)
+    testX, testY = loadTesting(FASHIONMNISTDIR, useGpu=useGpu)
     return trainX, trainY, testX, testY
 
 
@@ -243,17 +239,23 @@ def loadAffNist(useGpu=True, encoded=True):
     test_validation_instances = 320000
     features = 1600
     trainX = loadX(
-        root / f"{prefix}_trainX.npy", loadNpyFile, train_instances, features, useGpu,
+        root / f"{prefix}_trainX.npy",
+        loadNpyFile,
+        train_instances,
+        features,
+        useGpu=useGpu,
     )
-    trainY = loadY(root / f"{prefix}_trainY.npy", loadNpyFile, useGpu, encoded)
+    trainY = loadY(
+        root / f"{prefix}_trainY.npy", loadNpyFile, useGpu=useGpu, encoded=encoded
+    )
     testX = loadX(
         root / f"{prefix}_testX.npy",
         loadNpyFile,
         test_validation_instances,
         features,
-        useGpu,
+        useGpu=useGpu,
     )
-    testY = loadY(root / f"{prefix}_testY.npy", loadNpyFile, useGpu, encoded)
+    testY = loadY(root / f"{prefix}_testY.npy", loadNpyFile, useGpu=useGpu)
     return trainX, trainY, testX, testY
 
 
@@ -264,17 +266,23 @@ def loadCifar10(useGpu=True, encoded=True):
     test_validation_instances = 10000
     features = 1024
     trainX = loadX(
-        root / f"{prefix}_trainX.npy", loadNpyFile, train_instances, features, useGpu,
+        root / f"{prefix}_trainX.npy",
+        loadNpyFile,
+        train_instances,
+        features,
+        useGpu=useGpu,
     )
-    trainY = loadY(root / f"{prefix}_trainY.npy", loadNpyFile, useGpu, encoded)
+    trainY = loadY(
+        root / f"{prefix}_trainY.npy", loadNpyFile, useGpu=useGpu, encoded=encoded
+    )
     testX = loadX(
         root / f"{prefix}_testX.npy",
         loadNpyFile,
         test_validation_instances,
         features,
-        useGpu,
+        useGpu=useGpu,
     )
-    testY = loadY(root / f"{prefix}_testY.npy", loadNpyFile, useGpu, encoded)
+    testY = loadY(root / f"{prefix}_testY.npy", loadNpyFile, useGpu)
     return trainX, trainY, testX, testY
 
 
@@ -290,7 +298,7 @@ def loadDataset(dataset: DATASETS, useGpu=True, encoded=True):
         return loadMnistC(dataset, useGpu=useGpu, encoded=encoded)
     else:
         loadFunc = LOADING_FUNCS[dataset]
-        return loadFunc(useGpu, encoded)
+        return loadFunc(useGpu=useGpu, encoded=encoded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactored internal code as well

- Added verbosity to output of different functions.
- Saving the weights is done in a separate function now, with support for saving the binarized version of the weights as well.
- Evaluate function can be used to check the performance of a model on a dataset (with support for binarized weights)

- Loading functions for test datasets return normal versions, instead of the one-hot encoded ones (we can still set that to true when loading manually).
- The evaluate function excepts the datasets in the conventional shape (num_instances * num_features) instead of the other way around. This is done to make testing easier and more intuitive.
- The save_weights function uses a generator for creating binarized parameters instead of a list to minimize the memory footprint.

MAJOR Change: There is no non_binarized_version of weights during training loop of a binarized model. `self.weights` will always refer to the non-binarized weights. This is done to make train (and it's internal functions) atomic. This way, if the training is interrupted at any point in the training loop, we can still resume the training from that point without having to worry about self.weights referring the binary version (as was the case earlier). This would allow us to use this package for interactive testing in jupyter notebooks / ipython etc.