### PR TITLE
Fix relu

### DIFF
--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -64,8 +64,8 @@ def softmax_derivative(z: ndarray):
 
 
 def relu(x: ndarray):
-    xp = cp.get_array_module(x)
-    a = x.clip(a_min=0, a_max=xp.finfo(x.dtype).max)
+    a = x.copy()
+    a[x < 0] = 0
 
     return a
 
@@ -81,7 +81,7 @@ def relu_derivative(z: ndarray):
 
 def leaky_relu(x: ndarray):
     a = x.copy()
-    a[x <= 0] *= RELU_EPSILON
+    a[x < 0] *= RELU_EPSILON
 
     return a
 

--- a/test.py
+++ b/test.py
@@ -3,14 +3,14 @@ from mlpcode.loss import LossFuncs as lf
 from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset
 
-useGpu = True
+useGpu = False
 binarized = False
 dataset = DATASETS.fashion
 print("Loading {}".format(dataset))
-# trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
+trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 # Set quant_precision to any integer > 1 to quantize the input,
 # The quantized input having quant_precision + 1 unique elements
-trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu, quant_precision=2)
+# trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu, quant_precision=2)
 print("Finished loading {} data".format(dataset))
 
 layers = [trainX.shape[1], 512, 10]


### PR DESCRIPTION
Using xp.clip in relu caused problem when used with CPU as numpy.ndarray.clip has a different function signature than numpy.clip.
Also, a_max is required in np.clip but not in cp.clip. These issues, combined with benchmarks from my tests on Jupyter, led to this being the fastest implementation of ReLU (and Leaky ReLU) in our framework.