### PR TITLE
Add support for BNN (second try)

### DIFF
--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -116,6 +116,7 @@ def hard_tanh(z: ndarray):
     # equivalent to max(-1, min(z, 1))
     a = z.clip(-1, 1)
     # a = 2 * hard_sigmoid(z) - 1
+    # No need for the hard_sigmoid thing. Same as clip
 
     return a
 

--- a/mlpcode/activation.py
+++ b/mlpcode/activation.py
@@ -115,7 +115,6 @@ def unitstep(x: ndarray):
 def hard_tanh(z: ndarray):
     # equivalent to max(-1, min(z, 1))
     a = z.clip(-1, 1)
-    # a = 2 * hard_sigmoid(z) - 1
     # No need for the hard_sigmoid thing. Same as clip
 
     return a

--- a/mlpcode/loss.py
+++ b/mlpcode/loss.py
@@ -36,7 +36,7 @@ def cross_entropy_loss(yhat, y, eps=1e-15):
     return L
 
 
-def cross_entropy_derivative(yhat, y):
+def cross_entropy_derivative(yhat, y, _):
     """
     Derivative for Mean Squared Error
 
@@ -82,7 +82,7 @@ def mse(yhat, y):
     return cost
 
 
-def mse_derivative(yhat, y):
+def mse_derivative(yhat, y, _):
     """
     Derivative for Mean Squared Error
 
@@ -102,9 +102,31 @@ def mse_derivative(yhat, y):
     return yhat - y
 
 
+def squared_hinge_loss(yhat: cp.ndarray, y: cp.ndarray):
+    assert yhat.shape == y.shape
+
+    xp = cp.get_array_module(yhat)
+    loss = 1 - yhat * y
+    xp.maximum(0, loss, out=loss)
+    xp.square(loss, out=loss)
+
+    return loss.mean(axis=0)
+
+
+def squared_hinge_derivative(yhat, y, x):
+    assert yhat.shape == y.shape
+
+    v = yhat * y
+    grad = -y * x
+    grad[v > 1] = 0
+
+    return grad
+
+
 class LossFuncs(Enum):
     cross_entropy = "cross_entropy"
     mse = "mse"
+    sq_hinge = "squared_hinge"
 
     def __repr__(self):
         return self.value
@@ -116,9 +138,11 @@ class LossFuncs(Enum):
 LOSS_FUNCS = {
     LossFuncs.cross_entropy: cross_entropy_loss,
     LossFuncs.mse: mse,
+    LossFuncs.sq_hinge: squared_hinge_loss,
 }
 
 LOSS_DERIVATES = {
     LossFuncs.cross_entropy: cross_entropy_derivative,
     LossFuncs.mse: mse_derivative,
+    LossFuncs.sq_hinge: squared_hinge_derivative,
 }

--- a/mlpcode/loss.py
+++ b/mlpcode/loss.py
@@ -113,6 +113,7 @@ def squared_hinge_loss(yhat: cp.ndarray, y: cp.ndarray):
     return loss.mean(axis=0)
 
 
+# TODO: find a proper implemetation for the derivative
 def squared_hinge_derivative(yhat, y, x):
     assert yhat.shape == y.shape
 
@@ -126,7 +127,7 @@ def squared_hinge_derivative(yhat, y, x):
 class LossFuncs(Enum):
     cross_entropy = "cross_entropy"
     mse = "mse"
-    sq_hinge = "squared_hinge"
+    # sq_hinge = "squared_hinge"
 
     def __repr__(self):
         return self.value
@@ -138,11 +139,11 @@ class LossFuncs(Enum):
 LOSS_FUNCS = {
     LossFuncs.cross_entropy: cross_entropy_loss,
     LossFuncs.mse: mse,
-    LossFuncs.sq_hinge: squared_hinge_loss,
+    # LossFuncs.sq_hinge: squared_hinge_loss,
 }
 
 LOSS_DERIVATES = {
     LossFuncs.cross_entropy: cross_entropy_derivative,
     LossFuncs.mse: mse_derivative,
-    LossFuncs.sq_hinge: squared_hinge_derivative,
+    # LossFuncs.sq_hinge: squared_hinge_derivative,
 }

--- a/mlpcode/network.py
+++ b/mlpcode/network.py
@@ -17,7 +17,12 @@ ArrayList = List[np.ndarray]
 
 class Network(object):
     def __init__(
-        self, layers: List[int], useGpu=False, fineTuning=False, binarized=False,
+        self,
+        layers: List[int],
+        useGpu=False,
+        fineTuning=False,
+        binarized=False,
+        useBias=False,
     ):
 
         if useGpu:
@@ -27,15 +32,20 @@ class Network(object):
 
         self.layers = layers
         self.isBinarized = binarized
+        self.useBias = useBias
 
-        if fineTuning:
-            self.weights: ArrayList = []
-            self.biases: ArrayList = []
-        else:
+        self.weights: ArrayList = []
+        self.biases: ArrayList = []
+        self.H = []
+
+        if not fineTuning:
             # Xavier init
-            self.biases: ArrayList = [
-                self.xp.random.randn(y, 1).astype(np.float32) for y in layers[1:]
-            ]
+            if useBias:
+                self.biases: ArrayList = [
+                    self.xp.random.randn(y, 1).astype(np.float32) for y in layers[1:]
+                ]
+            else:
+                self.biases = [None for _ in layers[1:]]
             # Casting to float32 at multiple steps to keep the memory footprint low for each step
             self.weights: ArrayList = [
                 (
@@ -43,6 +53,10 @@ class Network(object):
                     * self.xp.sqrt(1 / l_minus_1)
                 ).astype(np.float32)
                 for l_minus_1, l in zip(layers[:-1], layers[1:])
+            ]
+            self.H = [
+                self.xp.sqrt(1.5 / sum(w.shape)).astype(np.float32)
+                for w in self.weights
             ]
         cp.cuda.Stream.null.synchronize()
 
@@ -62,12 +76,12 @@ class Network(object):
         return self.__isCompiled
 
     @staticmethod
-    def fromModel(
-        filePth: Path, useGpu=False, binarized=False,
-    ):
+    def fromModel(filePth: Path, useGpu=False, binarized=False, useBias=False):
         assert filePth.exists()
         print(f"\nLoading model from {filePth}\n")
-        nn = Network([], useGpu=useGpu, fineTuning=True, binarized=binarized,)
+        nn = Network(
+            [], useGpu=useGpu, fineTuning=True, binarized=binarized, useBias=useBias
+        )
         # If the file was saved using cupy, it would convert the weights (and biases)
         # list to an object array, so allow_pickle and subsequent conversion is for that
         with nn.xp.load(filePth, allow_pickle=True) as fp:
@@ -82,16 +96,20 @@ class Network(object):
             # Conversion done for the same reason allow_pickle is used above
             nn.weights = [nn.xp.array(x, dtype=np.float32) for x in npzfile[keyArr[0]]]
             nn.biases = [nn.xp.array(x, dtype=np.float32) for x in npzfile[keyArr[1]]]
+            nn.H = [
+                nn.xp.sqrt(1.5 / sum(w.shape)).astype(np.float32) for w in nn.weights
+            ]
             # Just to ensure consistency
             nn.layers = list(map(int, npzfile[keyArr[2]]))
             nn.num_layers = len(nn.layers) - 1
         return nn
 
     @staticmethod
-    def binarize(x: np.ndarray) -> np.ndarray:
-        newX = x.copy().astype(np.int8)
+    def binarize(x: np.ndarray, H=1.0) -> np.ndarray:
+        newX = x.copy()
         newX[x >= 0] = 1
         newX[x < 0] = -1
+        newX *= H
 
         cp.cuda.Stream.null.synchronize()
         return newX
@@ -217,7 +235,8 @@ class Network(object):
             if save_best_params and acc > best_accuracy:
                 best_accuracy = acc
                 best_weights = [w.copy() for w in self.weights]
-                best_biases = [b.copy() for b in self.biases]
+                if self.useBias:
+                    best_biases = [b.copy() for b in self.biases]
                 cp.cuda.Stream.null.synchronize()
 
         if save_best_params:
@@ -234,12 +253,13 @@ class Network(object):
         x, y = batch
         m = x.shape[0]
 
+        biases = self.biases
         if self.isBinarized:
-            weights = [self.binarize(w) for w in self.weights]
-            biases = [self.binarize(b) for b in self.biases]
+            weights = [self.binarize(w, H=h) for w, h in zip(self.weights, self.H)]
+            if self.useBias:
+                biases = [self.binarize(b, H=h) for b, h in zip(self.biases, self.H)]
         else:
             weights = self.weights
-            biases = self.biases
 
         delta_nabla_b, delta_nabla_w, cost = self.__backprop(x, y, weights, biases)
         cp.cuda.Stream.null.synchronize()
@@ -254,13 +274,14 @@ class Network(object):
         # [1,2,3,4]
         # [1,2,3,4]
         # [1,2,3,4]
-
-        nabla_b = [nb.mean(axis=1, keepdims=True) for nb in delta_nabla_b]
+        if self.useBias:
+            nabla_b = [nb.mean(axis=1, keepdims=True) for nb in delta_nabla_b]
         nabla_w = [(nw / m) for nw in delta_nabla_w]
         cp.cuda.Stream.null.synchronize()
 
         self.weights = [w - (lr * nw) for w, nw in zip(self.weights, nabla_w)]
-        self.biases = [b - (lr * nb) for b, nb in zip(self.biases, nabla_b)]
+        if self.useBias:
+            self.biases = [b - (lr * nb) for b, nb in zip(self.biases, nabla_b)]
         cp.cuda.Stream.null.synchronize()
 
         return cost
@@ -314,7 +335,9 @@ class Network(object):
         zs = []  # list to store all the z vectors, layer by layer
         # (num_features, num_examples)
         for w, b, afunc in zip(weights, biases, self.__activations):
-            z = self.xp.dot(w, a) + b
+            z = self.xp.dot(w, a)
+            if self.useBias:
+                z += b
             cp.cuda.Stream.null.synchronize()
             zs.append(z)
             a = afunc(z)
@@ -342,12 +365,13 @@ class Network(object):
         # Expected shape for X: num_instances * num_features
         # Expected shape for y: num_instances * 1
 
+        biases = self.biases
         if binarized:
-            weights = [self.binarize(w) for w in self.weights]
-            biases = [self.binarize(b) for b in self.biases]
+            weights = [self.binarize(w, H=h) for w, h in zip(self.weights, self.H)]
+            if self.useBias:
+                biases = [self.binarize(b, H=h) for b, h in zip(self.biases, self.H)]
         else:
             weights = self.weights
-            biases = self.biases
 
         batches = self.get_batches(X, y, batch_size=batch_size, n=X.shape[0])
         correct = 0
@@ -364,12 +388,16 @@ class Network(object):
             fName += "_binarized"
         filePth = MODELDIR / fName
 
+        biases = self.biases
         if binarized:
             weights = (self.binarize(w) for w in self.weights)
-            biases = (self.binarize(b) for b in self.biases)
+            if self.useBias:
+                biases = (self.binarize(b) for b in self.biases)
         else:
             weights = self.weights
-            biases = self.biases
+
+        if not self.useBias:
+            biases = [0 for _ in biases]
 
         weights_to_save = [cp.asnumpy(w) for w in weights]
         biases_to_save = [cp.asnumpy(b) for b in biases]

--- a/mlpcode/network.py
+++ b/mlpcode/network.py
@@ -83,7 +83,7 @@ class Network(object):
             nn.weights = [nn.xp.array(x, dtype=np.float32) for x in npzfile[keyArr[0]]]
             nn.biases = [nn.xp.array(x, dtype=np.float32) for x in npzfile[keyArr[1]]]
             # Just to ensure consistency
-            nn.layers = list(map(int, fp[keyArr[2]]))
+            nn.layers = list(map(int, npzfile[keyArr[2]]))
             nn.num_layers = len(nn.layers) - 1
         return nn
 
@@ -281,7 +281,7 @@ class Network(object):
         cost = float(self.__loss(activation, y).mean())
 
         # backward pass
-        dLdA = self.__loss_derivative(activation, y)  # expected shape: k * n
+        dLdA = self.__loss_derivative(activation, y, zs[-1])  # expected shape: k * n
         cp.cuda.Stream.null.synchronize()
 
         if (self.__outAF == af.identity) or (

--- a/mlpcode/utils.py
+++ b/mlpcode/utils.py
@@ -104,7 +104,7 @@ def oneHotEncode(classes: int, y: np.ndarray) -> np.ndarray:
     Returns
     -------
     np.ndarray
-        A 2D array of shape (y.shape[0], num_classes) and dtype np.uint8
+        A 2D array of shape (y.shape[0], num_classes) and dtype np.int8
 
     """
     xp = cp.get_array_module(y)
@@ -114,7 +114,7 @@ def oneHotEncode(classes: int, y: np.ndarray) -> np.ndarray:
 
     assert y.ndim == 1
 
-    oneHotEncoded = xp.eye(classes, dtype=np.uint8)[y]
+    oneHotEncoded = xp.eye(classes, dtype=np.int8)[y]
 
     return oneHotEncoded
 

--- a/test.py
+++ b/test.py
@@ -3,9 +3,9 @@ from mlpcode.loss import LossFuncs as lf
 from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset
 
-useGpu = False
+useGpu = True
 binarized = False
-dataset = DATASETS.fashion
+dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 # Set quant_precision to any integer > 1 to quantize the input,
@@ -13,10 +13,10 @@ trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 # trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu, quant_precision=2)
 print("Finished loading {} data".format(dataset))
 
-layers = [trainX.shape[1], 512, 10]
-epochs = 100
+layers = [trainX.shape[1], 500, 1000, 10]
+epochs = 500
 batchSize = 600
-lr = 0.07
+lr = 0.001
 # lr = LRScheduler(alpha=0.07, decay_rate=0.8, strategy=LRS.time)
 
 print("\nCreating neural net")
@@ -39,7 +39,7 @@ nn.train(trainX, trainY, epochs, batch_size=batchSize, save_best_params=True)
 nn.save_weights(modelName=str(dataset), binarized=False)
 
 # Change binarized to true to get the accuracy using binarized weights
-testingIsBinarized = False
+testingIsBinarized = True
 correct = nn.evaluate(testX, testY, batch_size=batchSize, binarized=testingIsBinarized)
 acc = correct / testX.shape[0] * 100.0
 print(

--- a/test.py
+++ b/test.py
@@ -4,7 +4,7 @@ from mlpcode.network import Network
 from mlpcode.utils import DATASETS, loadDataset
 
 useGpu = True
-binarized = False
+binarized = True
 dataset = DATASETS.mnist
 print("Loading {}".format(dataset))
 trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
@@ -14,7 +14,7 @@ trainX, trainY, testX, testY = loadDataset(dataset, useGpu=useGpu)
 print("Finished loading {} data".format(dataset))
 
 layers = [trainX.shape[1], 500, 1000, 10]
-epochs = 500
+epochs = 100
 batchSize = 600
 lr = 0.001
 # lr = 0.07
@@ -22,7 +22,7 @@ lr = 0.001
 
 print("\nCreating neural net")
 # Creating from scratch
-nn = Network(layers, useGpu=useGpu, binarized=binarized)
+nn = Network(layers, useGpu=useGpu, binarized=binarized, useBias=False)
 
 # Creating from a pretrained model
 # modelPath = MODELDIR / "mnist_1589624361.944349.npz"
@@ -39,8 +39,20 @@ nn.train(trainX, trainY, epochs, batch_size=batchSize, save_best_params=True)
 # Set binarized to true if you want to save the binary version of the weights
 nn.save_weights(modelName=str(dataset), binarized=False)
 
-# Change binarized to true to get the accuracy using binarized weights
-testingIsBinarized = True
+
+if binarized:
+    testingIsBinarized = True
+    correct = nn.evaluate(
+        testX, testY, batch_size=batchSize, binarized=testingIsBinarized
+    )
+    acc = correct / testX.shape[0] * 100.0
+    print(
+        "Accuracy on test set with {3} testing:\t{0} / {1} : {2:.03f}%".format(
+            correct, testX.shape[0], acc, ["normal", "binarized"][testingIsBinarized]
+        )
+    )
+
+testingIsBinarized = False
 correct = nn.evaluate(testX, testY, batch_size=batchSize, binarized=testingIsBinarized)
 acc = correct / testX.shape[0] * 100.0
 print(

--- a/test.py
+++ b/test.py
@@ -17,6 +17,7 @@ layers = [trainX.shape[1], 500, 1000, 10]
 epochs = 500
 batchSize = 600
 lr = 0.001
+# lr = 0.07
 # lr = LRScheduler(alpha=0.07, decay_rate=0.8, strategy=LRS.time)
 
 print("\nCreating neural net")
@@ -29,7 +30,7 @@ nn = Network(layers, useGpu=useGpu, binarized=binarized)
 # nn = Network.fromModel(modelPath, useGpu=useGpu, binarized=binarized)
 
 # Must compile the model before trying to train it
-nn.compile(lr=lr, hiddenAf=af.leaky_relu, outAf=af.softmax, lossF=lf.cross_entropy)
+nn.compile(lr=lr, hiddenAf=af.sign, outAf=af.softmax, lossF=lf.cross_entropy)
 
 # Save best will switch the model weights and biases to the ones with best accuracy at the end of the training loop
 nn.train(trainX, trainY, epochs, batch_size=batchSize, save_best_params=True)


### PR DESCRIPTION
- Binarize weights before every forward pass
- Binarize function now uses H and multiplies newX with it
- Sign function works better with low learning rate (start with 1e-3) and without bias
- Add option to use bias or not

MNIST test:
Layers: [784, 500, 1000, 10]
Learning rate: 0.001 (static)
Hidden Activation: sign (cause BNN)
Output activation: softmax
Loss: Cross-entropy
Epochs: 100
useBias = False

Best training accuracy:   84.883%
Normal Test accuracy:    65.08%
Binarized Test accuracy: 85.15%